### PR TITLE
Fix image path handling in TexValidator

### DIFF
--- a/modules/react_interactive_editor.py
+++ b/modules/react_interactive_editor.py
@@ -96,6 +96,12 @@ class ReactInteractiveEditor:
             result_json = self._call_llm([{"role": "user", "content": prompt}], system_prompt, json_mode=True)
             
             if result_json and "slides" in result_json:
+                slides = result_json.get("slides") or []
+                actual_total = len(slides)
+                recorded_total = result_json.get("total_slides")
+                if actual_total and recorded_total != actual_total:
+                    print(f"   ℹ️ 校正幻灯片数量: {recorded_total} -> {actual_total}")
+                result_json["total_slides"] = actual_total
                 print(f"   ✓ 已生成文档地图：{result_json['total_slides']} 页幻灯片")
                 return result_json
             else:

--- a/modules/react_interactive_editor_new.py
+++ b/modules/react_interactive_editor_new.py
@@ -109,6 +109,12 @@ class ReactInteractiveEditor:
             result_json = self._call_llm([{"role": "user", "content": prompt}], system_prompt, json_mode=True)
             
             if result_json and "slides" in result_json:
+                slides = result_json.get("slides") or []
+                actual_total = len(slides)
+                recorded_total = result_json.get("total_slides")
+                if actual_total and recorded_total != actual_total:
+                    print(f"   ℹ️ Adjusted slide count: {recorded_total} -> {actual_total}")
+                result_json["total_slides"] = actual_total
                 print(f"   ✓ Document map generated: {result_json['total_slides']} slides")
                 return result_json
             else:

--- a/modules/tex_validator.py
+++ b/modules/tex_validator.py
@@ -309,14 +309,16 @@ class TexValidator:
             src_file = os.path.join(actual_images_dir, img_filename)
             if os.path.exists(src_file) and os.path.isfile(src_file):
                 self.logger.info(f"找到图片: {src_file}")
-                # 计算从编译目录到图片的正确相对路径
-                # tex_file所在目录相对于项目根目录的路径
+                # 确保图片存在于临时images目录
+                target_file = os.path.join(images_dir, img_filename)
+                if not os.path.exists(target_file):
+                    os.makedirs(os.path.dirname(target_file), exist_ok=True)
+                    shutil.copy2(src_file, target_file)
+                    self.logger.info(f"复制图片到临时目录: {src_file} -> {target_file}")
+                # 计算从编译目录到临时images目录的相对路径
                 tex_dir = os.path.dirname(os.path.abspath(tex_file))
-                # actual_images_dir的绝对路径
-                images_abs_path = os.path.abspath(actual_images_dir)
-                # 计算相对路径
-                rel_path = os.path.relpath(images_abs_path, tex_dir)
-                new_path = f"{rel_path}/{img_filename}"
+                rel_path = os.path.relpath(images_dir, tex_dir)
+                new_path = os.path.join(rel_path, img_filename).replace(os.sep, "/")
                 tex_content = tex_content.replace(f"{{{img_path}}}", f"{{{new_path}}}")
                 self.logger.info(f"更新图片路径: {img_path} -> {new_path}")
             else:


### PR DESCRIPTION
## 修复内容
- TexValidator 在处理图片时，先将源图复制到编译临时目录的 `images/` 下并改写为相对路径，避免绝对路径在不同环境中失效。
- 交互式 LaTeX 编辑器在生成文档地图时，使用 `slides` 列表的实际长度覆盖 LLM 返回的总页数，修复“文档状态”显示多 1 页的问题。

## 复现问题
1. 使用原始代码运行 `python -m modules.tex_validator output/tex/1761826825/output.tex`（或触发自动验证流程），日志出现 `pdftex.def Error: File ... not found`，PDF 中图片缺失。
2. 启动交互式编辑器，初始输出或输入 `status`，看到幻灯片数量比 PDF 实际页数多 1。

## 验证方式
- 应用补丁后重复验证流程，编译成功且日志中不再出现 `pdftex.def` 报错，生成的 `output/tex/1761826825/output.pdf` 图片正常。
- 再次启动交互式编辑器，确认“📊 文档状态”显示的页数与 PDF 实际页数一致。